### PR TITLE
Change require to wpackagist-plugin/user-switching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
 	},
 	"require": {
 		"composer/installers": "^1",
-		"johnbillion/user-switching": "^1"
+		"wpackagist-plugin/user-switching": "^1"
 	}
 }


### PR DESCRIPTION
Composer complains that `Package johnbillion/user-switching is abandoned, you should avoid using it. Use wpackagist-plugin/user-switching instead.`